### PR TITLE
Added schema change for project status

### DIFF
--- a/app/api/project/[id]/route.ts
+++ b/app/api/project/[id]/route.ts
@@ -130,3 +130,33 @@ export async function PATCH(req: Request, context: { params: { id: string } } ){
         );
     }
 }
+
+
+//Delete method to soft delete a project record based on Id, will set status to INACTIVE
+export async function DELETE(req: Request, context: { params: { id: string } } ){
+    try{
+        const params = await context.params;
+
+        const projectId = Number(params.id);
+
+        if (isNaN(projectId)) {
+            return NextResponse.json({ error: "Invalid Project ID" }, { status: 400 });
+        }
+        
+        const deletedProject = await prisma.project.update({
+            where: { projectId },
+            data: {
+                status: "INACTIVE"
+            }
+        });
+
+        return NextResponse.json(deletedProject);
+
+    }catch(error){
+        console.error(error);
+        return NextResponse.json(
+            {error: "Unable to Delete Project Record"},
+             {status: 500 }
+         );
+    }
+}

--- a/app/api/project/employee/[id]/route.ts
+++ b/app/api/project/employee/[id]/route.ts
@@ -1,0 +1,59 @@
+//app/api/project/employee/[id]/route.ts
+import { NextResponse } from "next/server";
+import {prisma} from "@/lib/db"
+
+const validStatuses = ["ACTIVE", "INACTIVE"] as const;
+type ValidStatus = (typeof validStatuses)[number];
+
+export async function GET( req: Request, context: { params: { id: string } }) {
+  try {
+
+    const params = await context.params;
+    const employeeId = Number(params.id);
+
+    if (isNaN(employeeId)) {
+      return NextResponse.json({ error: "Invalid employeeId" }, { status: 400 });
+    }
+
+    const url = new URL(req.url);
+    const statusParamRaw = url.searchParams.get("status"); // ACTIVE, INACTIVE, ALL
+
+    let statusFilter: ValidStatus | undefined;
+    if (statusParamRaw && statusParamRaw !== "ALL") {
+      if (validStatuses.includes(statusParamRaw as ValidStatus)) {
+        statusFilter = statusParamRaw as ValidStatus;
+      } else {
+            return NextResponse.json(
+                { error: "Invalid status query parameter. Must be ACTIVE, INACTIVE, or ALL." }, 
+                { status: 400 }
+        );
+      }
+    }
+
+    // Fetch assignments and include project
+    const assignments = await prisma.projectAssigned.findMany({
+      where: {
+        employeeId,
+        project: statusFilter ? { status: statusFilter } : undefined
+      },
+      include: {
+        project: true
+      },
+      orderBy: { assignedDate: "asc" }
+    });
+
+    // Instead of returning only projects, include assignedDate
+    const result = assignments.map(a => ({
+      assignedDate: a.assignedDate,
+      project: a.project
+    }));
+
+    return NextResponse.json(result);
+  } catch(error){
+        console.error(error);
+        return NextResponse.json(
+            {error: "Unable to Retrieve Employee Project records"},
+            {status: 500 }
+        );
+    }
+}

--- a/app/api/project/route.ts
+++ b/app/api/project/route.ts
@@ -2,25 +2,45 @@
 import { NextResponse } from "next/server";
 import {prisma} from "@/lib/db"
 
-//Get method to retrieve project information
-export async function GET(){
+const validStatuses = ["ACTIVE", "INACTIVE"] as const;
+type ValidStatus = (typeof validStatuses)[number];
 
-    try{
-        const projects=await prisma.project.findMany({
-            include:{
-                assigned:true
-            },
-        });
+// GET method to retrieve projects with soft-delete support
+export async function GET(req: Request) {
+  try {
+    // Parse query parameter
+    const url = new URL(req.url);
+    const statusParamRaw = url.searchParams.get("status"); // "ACTIVE", "INACTIVE", "ALL", or null
+
+    let statusFilter: ValidStatus | undefined;
+
+    if (statusParamRaw && statusParamRaw !== "ALL") {
+      if (validStatuses.includes(statusParamRaw as ValidStatus)) {
+        statusFilter = statusParamRaw as ValidStatus;
+      } else {
+        return NextResponse.json(
+          { error: "Invalid status query parameter. Must be ACTIVE, INACTIVE, or ALL." },
+          { status: 400 }
+        );
+      }
+    }
+
+    // Build Prisma where clause
+    const whereClause = statusFilter ? { status: statusFilter } : {};
+
+    const projects = await prisma.project.findMany({
+      where: whereClause,
+      orderBy: { startDate: "asc" } // optional: sort by startDate
+    });
 
     return NextResponse.json(projects);
-
-    }catch(error){
-        console.error(error);
-        return NextResponse.json(
-            {error: "Unable to Retrieve Project Data"},
-            {status: 500 }
-        );
-    }
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { error: "Unable to retrieve project data" },
+      { status: 500 }
+    );
+  }
 }
 
 // POST method to create a new project record

--- a/prisma/migrations/20260314184503_add_project_status/migration.sql
+++ b/prisma/migrations/20260314184503_add_project_status/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "ProjectStatus" AS ENUM ('ACTIVE', 'INACTIVE');
+
+-- AlterTable
+ALTER TABLE "Project" ADD COLUMN     "status" "ProjectStatus" NOT NULL DEFAULT 'ACTIVE';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -79,6 +79,7 @@ model Project {
   startDate   DateTime
   endDate     DateTime
   location    String
+  status      ProjectStatus     @default(ACTIVE)
   assigned    ProjectAssigned[]
 }
 
@@ -122,4 +123,9 @@ enum Role {
   ADMIN
   MANAGER
   EMPLOYEE
+}
+
+enum ProjectStatus {
+  ACTIVE
+  INACTIVE
 }


### PR DESCRIPTION
Added project status schema change, as well as added way to query for a specific employees projects under the path app/api/project/employee/[id] with an optional parameter of ALL, ACTIVE, INACTIVE, this parameter is now available under the GET method for all projects. In addition a DELETE method has been created for project/[id] that allows for a soft delete, changing status from active to inactive. Well tested with postman. 